### PR TITLE
Expose defaults object for modification

### DIFF
--- a/bootstrap-add-clear.js
+++ b/bootstrap-add-clear.js
@@ -106,6 +106,8 @@
     });
   };
 
+  $.fn[pluginName].Constructor = Plugin;
+
   var defaults = $.fn[pluginName].defaults = {
     closeSymbol: "",
     symbolClass: 'glyphicon glyphicon-remove-circle',

--- a/bootstrap-add-clear.js
+++ b/bootstrap-add-clear.js
@@ -4,22 +4,7 @@
  */
 ;(function($, window, document, undefined) {
 
-  // Create the defaults once
-  var pluginName = "addClear",
-    defaults = {
-      closeSymbol: "",
-      symbolClass: 'glyphicon glyphicon-remove-circle',
-      color: "#CCC",
-      top: 0,
-      right: 0,
-      returnFocus: true,
-      showOnLoad: false,
-      onClear: null,
-      hideOnBlur: false,
-      clearOnEscape: true,
-      wrapperClass: '',
-      zindex: 100
-    };
+  var pluginName = "addClear";
 
   // The actual plugin constructor
   function Plugin(element, options) {
@@ -119,6 +104,21 @@
           new Plugin(this, options));
       }
     });
+  };
+
+  var defaults = $.fn[pluginName].defaults = {
+    closeSymbol: "",
+    symbolClass: 'glyphicon glyphicon-remove-circle',
+    color: "#CCC",
+    top: 0,
+    right: 0,
+    returnFocus: true,
+    showOnLoad: false,
+    onClear: null,
+    hideOnBlur: false,
+    clearOnEscape: true,
+    wrapperClass: '',
+    zindex: 100
   };
 
 })(jQuery, window, document);


### PR DESCRIPTION
This PR exposes the `defaults` object as `$.fn.addClear.defaults`, so that an app can modify default options globally before usage.

I also exposed the `Plugin` class as `$.fn.addClear.Constructor` in case anyone wants to use this with `instanceof` (can be useful in unit tests).
